### PR TITLE
Fix - Allow to override tree parent key in the model

### DIFF
--- a/src/Concern/InteractWithTree.php
+++ b/src/Concern/InteractWithTree.php
@@ -91,7 +91,8 @@ trait InteractWithTree
             $records = $this->getRecords()->keyBy(fn ($record) => $record->getAttributeValue($record->getKeyName()));
 
             $unnestedArr = [];
-            $this->unnestArray($unnestedArr, $list, Utils::defaultParentId());
+            $defaultParentId = Utils::defaultParentId();
+            $this->unnestArray($unnestedArr, $list, $defaultParentId);
             $unnestedArrData = collect($unnestedArr)
                 ->map(fn (array $data, $id) => ['data' => $data, 'model' => $records->get($id)])
                 ->filter(fn (array $arr) => !is_null($arr['model']));
@@ -101,6 +102,7 @@ trait InteractWithTree
                     if ($model instanceof Model) {
                         $parentColumnName = method_exists($model, 'determineParentColumnName') ? $model->determineParentColumnName() : Utils::parentColumnName();
                         $orderColumnName = method_exists($model, 'determineOrderColumnName') ? $model->determineOrderColumnName() : Utils::orderColumnName();
+                        $newParentId = $newParentId === $defaultParentId && method_exists($model, 'defaultParentKey') ? $model::defaultParentKey() : $newParentId;
 
                         $model->{$parentColumnName} = $newParentId;
                         $model->{$orderColumnName} = $newOrder;

--- a/src/Concern/ModelTree.php
+++ b/src/Concern/ModelTree.php
@@ -27,7 +27,7 @@ trait ModelTree
     public static function bootModelTree()
     {
         static::saving(function(Model $model) {
-            if (empty($model->{$model->determineParentColumnName()}) || $model->{$model->determineParentColumnName()} === 0) {
+            if (empty($model->{$model->determineParentColumnName()}) || $model->{$model->determineParentColumnName()} === -1) {
                 $model->{$model->determineParentColumnName()} = static::defaultParentKey();
             }
             if (empty($model->{$model->determineOrderColumnName()}) || $model->{$model->determineOrderColumnName()} === 0) {


### PR DESCRIPTION
This PR fixes a case when the model needs to use a parent key which is differ from the defined global one and the model sets it via `defaultParentKey` static method.
Use case: by default the parent key is `-1`, the model sets it to `0`. Without this PR after saving the tree all the parent nodes would have `-1` as a parent key. The PR fixes that and all the saved nodes would have `0` as it needed.