### PR TITLE
Tree node collapsed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ You can customize a collapsed state of the node. If you would like to show your 
 ```php
 public function getNodeCollapsedState(?\Illuminate\Database\Eloquent\Model $record = null): bool
 {
-    return false;
+    // All tree nodes will be collapsed by default.
+    return true;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,15 @@ public function getTreeRecordIcon(?\Illuminate\Database\Eloquent\Model $record =
 ```
 ![tree-icon](https://github.com/solutionforest/filament-tree/assets/68525320/6a1ef719-9029-4e91-a20a-515a514c4326)
 
+#### Node collapsed state
+You can customize a collapsed state of the node. If you would like to show your tree initially collapsed you can use:
+
+```php
+public function getNodeCollapsedState(?\Illuminate\Database\Eloquent\Model $record = null): bool
+{
+    return false;
+}
+```
 
 ### Pages
 This plugin enables you to create tree pages in the admin panel. To create a tree page for a model, use the `make:filament-tree-page` command. For example, to create a tree page for the ProductCategory model, you can run:

--- a/resources/views/components/tree/item.blade.php
+++ b/resources/views/components/tree/item.blade.php
@@ -14,6 +14,7 @@
     $parentKey = $tree->getParentKey($record);
 
     $children = $record->children;
+    $collapsed = $this->getNodeCollapsedState($record);
 
     $actions = $tree->getActions();
 @endphp
@@ -48,10 +49,10 @@
                 'dd-item-btns',
                 'hidden' => ! count($children),
             ])>
-                <button data-action="expand" class="hidden">
+                <button data-action="expand" @class(['hidden' => ! $collapsed])>
                     <x-heroicon-o-chevron-down class="text-gray-400 w-4 h-4"/>
                 </button>
-                <button data-action="collapse">
+                <button data-action="collapse" @class(['hidden' => $collapsed])>
                     <x-heroicon-o-chevron-up class="text-gray-400 w-4 h-4"/>
                 </button>
             </div>
@@ -64,7 +65,7 @@
         @endif
     </div>
     @if (count($children))
-        <x-filament-tree::tree.list :records="$children" :containerKey="$containerKey" :tree="$tree" />
+        <x-filament-tree::tree.list :records="$children" :containerKey="$containerKey" :tree="$tree" :collapsed="$collapsed"/>
     @endif
     <div class="rounded-lg border border-gray-300 mb-2 w-full px-4 py-4 animate-pulse hidden" 
         wire:loading.class.remove.delay="hidden" 

--- a/resources/views/components/tree/list.blade.php
+++ b/resources/views/components/tree/list.blade.php
@@ -1,5 +1,14 @@
-@props(['records', 'containerKey', 'tree'])
-<ol class="filament-tree-list dd-list">
+@props([
+    'records',
+    'containerKey',
+    'tree',
+    'collapsed' => null,
+])
+<ol @class([
+    'filament-tree-list',
+    'dd-list',
+    'hidden' => $collapsed,
+])>
     @foreach ($records ?? [] as $record)
         @php
             $title = $this->getTreeRecordTitle($record);

--- a/src/Concern/InteractWithTree.php
+++ b/src/Concern/InteractWithTree.php
@@ -81,6 +81,11 @@ trait InteractWithTree
         return $this->getCachedTree()->getParentKey($record);
     }
 
+    public function getNodeCollapsedState(?Model $record = null): bool
+    {
+        return false;
+    }
+
     /**
      * Update the tree list.
      */


### PR DESCRIPTION
This PR lets you control the node collapsed state as well as the default tree collapsed state. For example, for long trees it's better to have them initially collapsed to overview all the root nodes and manually expand some nodes.

By default, collapsed is `false` but overriding resource's `getNodeCollapsedState()` method, user can set a whole tree as collapsed or selectively collapse nodes:
```php
    public function getNodeCollapsedState(?Model $record = null): bool
    {
        // All the tree nodes will be collapsed.
        // return true;
       
        // Collapsed will be a node with id 3.
        // return $record->id == 3;

       // The tree nodes will be expanded.
       return false;
    }

```