### PR TITLE
Fix issues with $fillable vs $guarded

### DIFF
--- a/src/Concern/ModelTree.php
+++ b/src/Concern/ModelTree.php
@@ -16,9 +16,13 @@ trait ModelTree
 
     public function initializeModelTree()
     {
-        $this->fillable[] = $this->determineOrderColumnName();
-        $this->fillable[] = $this->determineParentColumnName();
-        $this->fillable[] = $this->determineTitleColumnName();
+        if (!empty($this->fillable)) {
+            $this->mergeFillable([
+                $this->determineOrderColumnName(),
+                $this->determineParentColumnName(),
+                $this->determineTitleColumnName(),
+            ]);
+        }
     }
 
     /**

--- a/src/Concern/ModelTree.php
+++ b/src/Concern/ModelTree.php
@@ -16,7 +16,7 @@ trait ModelTree
 
     public function initializeModelTree()
     {
-        if (!empty($this->fillable)) {
+        if (!empty($this->getFillable())) {
             $this->mergeFillable([
                 $this->determineOrderColumnName(),
                 $this->determineParentColumnName(),


### PR DESCRIPTION
When using $guarded = ['id'] instead of $fillable, there is no need to add attributes to the $fillable array. This resolves issues I encountered while using $guarded = ['id'] on my model.