### PR TITLE
Fix is Modal is Hidden function

### DIFF
--- a/src/Concern/HasActions.php
+++ b/src/Concern/HasActions.php
@@ -183,8 +183,16 @@ trait HasActions
     {
         $action = $this->getMountedTreeAction();
 
-        if ($action->isModalHidden()) {
-            return false;
+        if(method_exists($action, 'isHidden')) {
+            if ($action->isHidden()) {
+                return false;
+            }
+        }
+        
+        if(method_exists($action, 'isModalHidden')) {
+            if ($action->isModalHidden()) {
+                return false;
+            }
         }
 
         return $action->getModalDescription() ||


### PR DESCRIPTION
The new Filament version don't have the function `isModalHidden`, so I added this code:

````php
if (method_exists($action, 'isHidden')) {
            if ($action->isHidden()) {
                return false;
            }
        }

        if (method_exists($action, 'isModalHidden')) {
            if ($action->isModalHidden()) {
                return false;
            }
        }
```

On the trait `HasAction` to keep the compatibility with older or newer versions.