### PR TITLE
Mirror item spacing when there are actions

### DIFF
--- a/resources/views/components/tree/item.blade.php
+++ b/resources/views/components/tree/item.blade.php
@@ -60,7 +60,7 @@
         </div>
 
         @if (count($actions))
-            <div class="dd-nodrag ml-auto rtl:ml-0 rtl:mr-auto">
+            <div class="dd-nodrag ml-auto mr-4 rtl:ml-4 rtl:mr-auto">
                 <x-filament-tree::actions :actions="$actions" :record="$record" />
             </div>
         @endif


### PR DESCRIPTION
Items' actions were stuck to the right with no spacing, added the same spacing as for the left of the item's text