### PR TITLE
Allow null value for default parent_id

### DIFF
--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -27,9 +27,9 @@ class Utils
         return config('filament-tree.column_name.title', 'title');
     }
 
-    public static function defaultParentId(): int
+    public static function defaultParentId(): ?int
     {
-        return (int) config('filament-tree.default_parent_id', -1);
+        return config('filament-tree.default_parent_id', null);
     }
 
     public static function defaultChildrenKeyName(): string


### PR DESCRIPTION
When working with packages such as [Laravel tree](https://github.com/xalaida/laravel-tree), we need the parent-less models to have `null` as parent_id.

Currently, if we configure `null` in the configuration file, it is parsed to 0 because of the integer cast of the plugin.

This change allow setting `null` as the default parent id, which doesn't seems to break the plugin on my setup. 