### PR TITLE
fix: replace blade component namespace with Filament 4 version

### DIFF
--- a/resources/views/components/modal/actions.blade.php
+++ b/resources/views/components/modal/actions.blade.php
@@ -1,7 +1,7 @@
-<x-filament-actions::actions
+<x-filament::actions
     :attributes="\Filament\Support\prepare_inherited_attributes($attributes)"
     :alignment="config('filament.layout.actions.modal.actions.alignment')"
     :dark-mode="config('filament.dark_mode')"
 >
     {{ $slot }}
-</x-filament-actions::actions>
+</x-filament::actions>


### PR DESCRIPTION
invalid blade component namespace causing error (screenshot below)

<img width="621" height="116" alt="image" src="https://github.com/user-attachments/assets/8c10a2e3-baac-4d46-a797-ca100e2046f3" />
