### PR TITLE
Update notification title on save action

### DIFF
--- a/src/Concern/InteractWithTree.php
+++ b/src/Concern/InteractWithTree.php
@@ -147,7 +147,7 @@ trait InteractWithTree
 
             Notification::make()
                 ->success()
-                ->title(__('filament-actions::edit.single.modal.actions.save.label'))
+                ->title(__('filament-actions::edit.single.notifications.saved.title'))
                 ->send();
 
             // Reload data


### PR DESCRIPTION
Correct the notification title displayed on save action, which previously used an incorrect value from the action modal button.